### PR TITLE
Check if password file exists before accessing it

### DIFF
--- a/haste.bash
+++ b/haste.bash
@@ -2,7 +2,10 @@
 #place this file in your path. then send stdoud to | haste
 
 #optional for ldap or other simple auth in the format user.name:password@ (you need the @ after)
-password="$(< ~/.hidden_password)"
+if [ -f ~/.hidden_password ]
+then
+    password="$(< ~/.hidden_password)"
+fi
 
 #change this to your haste server
 url="hastebin.com"


### PR DESCRIPTION
If the password fail does not exist, the script used to print a
file-not-found error, which also made execution slower.